### PR TITLE
Added the GPS plugin on mybot.gazebo

### DIFF
--- a/mybot_ws/src/mybot_description/urdf/mybot.gazebo
+++ b/mybot_ws/src/mybot_description/urdf/mybot.gazebo
@@ -119,4 +119,19 @@
     </sensor>
   </gazebo>
 
+  <!-- GPS -->
+  <gazebo>
+  <plugin name="novatel_gps_sim" filename="libhector_gazebo_ros_gps.so">
+    <alwaysOn>1</alwaysOn>
+    <updateRate>10.0</updateRate>
+    <bodyName>chassis</bodyName>
+    <topicName>fix</topicName>
+    <velocityTopicName>fix_velocity</velocityTopicName>
+    <drift>5.0 5.0 5.0</drift>
+    <gaussianNoise>0.1 0.1 0.1</gaussianNoise>
+    <velocityDrift>0 0 0</velocityDrift>
+    <velocityGaussianNoise>0.1 0.1 0.1</velocityGaussianNoise>
+  </plugin>
+</gazebo>
+
 </robot>


### PR DESCRIPTION
Copied the GPS plugin into mybot.gazebo and then checked that gazebo was
publishing a sensor_msgs/NavSatFix Message under the /fix topic. The plugin
is a hector gazebo plugin so the hector plugin library should be installed
from source for this to work.